### PR TITLE
Fix various issues

### DIFF
--- a/src/pytest_hook.py
+++ b/src/pytest_hook.py
@@ -89,7 +89,8 @@ def pytest_runtest_logreport(report: TestReport):
     cov.stop()
 
     test_id = report.nodeid
-    used_files = cov.get_data().measured_files()
+    data = cov.get_data()
+    used_files = [f for f in data.measured_files() if len(data.lines(f))]
 
     dep_cache.update_test(test_id, used_files, report.outcome)
 

--- a/src/pytest_hook.py
+++ b/src/pytest_hook.py
@@ -78,6 +78,7 @@ def pytest_runtest_logstart(nodeid: str, location: tuple[str, int | None, str]):
         run_start = time.perf_counter()
 
     cov = coverage.Coverage(data_file=None)
+    cov.config.disable_warnings = ["module-not-measured", "no-data-collected"]
     cov.start()
 
 


### PR DESCRIPTION
First suppresses two warnings from `coverage.py` we don't care about that affected `click` and `loguru`

Second prevents every test in `click` from depending on every file, even if it isn't actually used (just measured).